### PR TITLE
[Feat] 붕어빵 갯수 가져오기

### DIFF
--- a/src/main/java/com/nyanggle/nyangmail/controller/FishBreadController.java
+++ b/src/main/java/com/nyanggle/nyangmail/controller/FishBreadController.java
@@ -5,7 +5,6 @@ import com.nyanggle.nyangmail.interfaces.dto.fishbread.FishBreadCreateReqDto;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.FishBreadListResDto;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.FishBreadResDto;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.SearchCondition;
-import com.nyanggle.nyangmail.oauth.UserPrincipal;
 import com.nyanggle.nyangmail.oauth.jwt.UserToken;
 import com.nyanggle.nyangmail.service.FishBreadService;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +14,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -74,8 +72,23 @@ public class FishBreadController {
         return ResponseEntity.ok(resDto);
     }
 
-    @GetMapping("/count/{uuid}")
-    public ResponseEntity<Long> findFishBreadCount(@PathVariable(value = "uuid") String receiverUid) {
-        return ResponseEntity.ok(fishBreadService.findFishBreadCount(receiverUid));
+    /**
+     * 안 읽은 붕어빵의 갯수
+     * @param userToken
+     * @return
+     */
+    @GetMapping("/{uuid}/notread")
+    public ResponseEntity<Long> findFishBreadCountNotRead(@AuthUser @AuthenticationPrincipal UserToken userToken) {
+        return ResponseEntity.ok(fishBreadService.findFishBreadCountNotRead(userToken.getUserId()));
+    }
+
+    /**
+     * 전체 붕어빵의 갯수
+     * @param cartUUid
+     * @return
+     */
+    @GetMapping("/{uuid}/total")
+    public ResponseEntity<Long> findFishBreadCountAll(@PathVariable(value = "uuid") String cartUUid) {
+        return ResponseEntity.ok(fishBreadService.findFishBreadCountAll(cartUUid));
     }
 }

--- a/src/main/java/com/nyanggle/nyangmail/persistence/repository/CustomFishBreadRepository.java
+++ b/src/main/java/com/nyanggle/nyangmail/persistence/repository/CustomFishBreadRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.domain.Pageable;
 
 public interface CustomFishBreadRepository {
     Page<FishBreadListResDto> searchByCondition(String uUid, SearchCondition searchCondition, Pageable pageable);
-    Long findFishBreadCount(String uUid);
+    Long findFishBreadCountAll(String cartUUid);
+    Long findFishBreadCountNotRead(String uUid);
 }

--- a/src/main/java/com/nyanggle/nyangmail/service/FishBreadService.java
+++ b/src/main/java/com/nyanggle/nyangmail/service/FishBreadService.java
@@ -12,5 +12,6 @@ public interface FishBreadService {
     FishBreadResDto findByFishUid(String uUid, Long fishId);
     void fishBreadstatusChange(Long fishId);
     Page<FishBreadListResDto> findBySearchCondition(String uuid, Pageable pageable, SearchCondition searchCondition);
-    Long findFishBreadCount(String receiverUid);
+    Long findFishBreadCountAll(String cartUUid);
+    Long findFishBreadCountNotRead(String userId);
 }

--- a/src/main/java/com/nyanggle/nyangmail/service/FishBreadServiceImpl.java
+++ b/src/main/java/com/nyanggle/nyangmail/service/FishBreadServiceImpl.java
@@ -59,7 +59,12 @@ public class FishBreadServiceImpl implements FishBreadService{
     }
 
     @Override
-    public Long findFishBreadCount(String receiverUid) {
-        return customFishBreadRepository.findFishBreadCount(receiverUid);
+    public Long findFishBreadCountAll(String cartUUid) {
+        return customFishBreadRepository.findFishBreadCountAll(cartUUid);
+    }
+
+    @Override
+    public Long findFishBreadCountNotRead(String userId) {
+        return customFishBreadRepository.findFishBreadCountNotRead(userId);
     }
 }


### PR DESCRIPTION
- 전체 붕어빵 갯수와 안 읽은 붕어빵 갯수

## 작업 내용
### 전체 붕어빵 갯수 API

- 로그인 한 유저, 로그인하지 않은 유저 모두 해당 프로필의 유저의 받은 붕어빵을 볼 수 있음. 


### 안 읽은 붕어빵
- 로그인 한 유저가 자신의 프로필에 가면 호출.
- 100개 까지의 결과를 반환.
  - 99개 이상까지만 보여줄 것이기 때문에 100을 반환 받으면 99+ 처리
