### PR TITLE
[Feat] 붕어빵 메인 카트 API 수정

### DIFF
--- a/src/main/java/com/nyanggle/nyangmail/controller/FishBreadController.java
+++ b/src/main/java/com/nyanggle/nyangmail/controller/FishBreadController.java
@@ -1,11 +1,13 @@
 package com.nyanggle.nyangmail.controller;
 
 import com.nyanggle.nyangmail.config.AuthUser;
+import com.nyanggle.nyangmail.exception.user.UnAuthorizedException;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.FishBreadCreateReqDto;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.FishBreadListResDto;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.FishBreadResDto;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.SearchCondition;
 import com.nyanggle.nyangmail.oauth.jwt.UserToken;
+import com.nyanggle.nyangmail.persistence.entity.User;
 import com.nyanggle.nyangmail.service.FishBreadService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,13 +33,29 @@ import javax.validation.Valid;
 @Slf4j
 public class FishBreadController {
     private final FishBreadService fishBreadService;
-    
+
     @PostMapping("/{uuid}")
     public ResponseEntity createFishBread(@RequestBody @Valid FishBreadCreateReqDto reqDto,
                                           @PathVariable(value = "uuid") String receiverUid) {
         fishBreadService.create(reqDto, receiverUid);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    /**
+     * 카트에 들어갔을 때 가져오는
+     * 전체 붕어빵 갯수,
+     * 읽지 않은 붕어빵 갯수
+     * 닉네임
+     * @param userToken
+     * @param cartUUid
+     * @return
+     */
+    @GetMapping("/{uuid}")
+    public ResponseEntity getMainInfo(@AuthenticationPrincipal UserToken userToken,
+                                          @PathVariable(value = "uuid") String cartUUid) {
+        return ResponseEntity.ok(fishBreadService.getMainInfo(cartUUid, userToken));
+    }
+
 
     /**
      * 붕어빵 목록
@@ -59,43 +77,18 @@ public class FishBreadController {
      * @param fishId
      * @return
      */
-    @GetMapping("/{fishId}")
+    @GetMapping("/{uuid}/{fishId}")
     public ResponseEntity<FishBreadResDto> findFishBreadByUUID(@PathVariable(name = "fishId") Long fishId,
+                                                               @PathVariable(name = "uuid") String cartId,
                                               @AuthUser @AuthenticationPrincipal UserToken userToken) {
-        FishBreadResDto resDto = fishBreadService.findByFishUid(userToken.getUserId(), fishId);
+        if(!cartId.equals(userToken.getUserId())) {
+            throw new UnAuthorizedException();
+        }
+        FishBreadResDto resDto = fishBreadService.findByFishUid(cartId, fishId);
         fishBreadService.fishBreadstatusChange(fishId);
         return ResponseEntity.ok(resDto);
     }
 
-    /**
-     * 내 프로필에서 안 읽은 붕어빵의 갯수 ( 최대 100개 )
-     * @param userToken
-     * @return
-     */
-    @GetMapping("/{uuid}/myunread")
-    public ResponseEntity<Long> findFishBreadCountNotReadMy(@AuthUser @AuthenticationPrincipal UserToken userToken) {
-        return ResponseEntity.ok(fishBreadService.findFishBreadCountNotReadMy(userToken.getUserId()));
-    }
-
-    /**
-     * 남 프로필에서 안 읽은 붕어빵의 갯수 ( 최대 6개 )
-     * @param cartUUid
-     * @return
-     */
-    @GetMapping("/{uuid}/unread")
-    public ResponseEntity<Long> findFishBreadCountNotReadOther(@PathVariable(name = "uuid")String cartUUid) {
-        return ResponseEntity.ok(fishBreadService.findFishBreadCountNotReadOther(cartUUid));
-    }
-
-    /**
-     * 전체 붕어빵의 갯수
-     * @param cartUUid
-     * @return
-     */
-    @GetMapping("/{uuid}/total")
-    public ResponseEntity<Long> findFishBreadCountAll(@PathVariable(value = "uuid") String cartUUid) {
-        return ResponseEntity.ok(fishBreadService.findFishBreadCountAll(cartUUid));
-    }
     @DeleteMapping("/{fishId}")
     public void deleteFishBread(@PathVariable(name = "fishId") Long fishId,
                                 @AuthUser @AuthenticationPrincipal UserToken userToken){

--- a/src/main/java/com/nyanggle/nyangmail/interfaces/dto/fishbread/MainInfoResDto.java
+++ b/src/main/java/com/nyanggle/nyangmail/interfaces/dto/fishbread/MainInfoResDto.java
@@ -1,0 +1,14 @@
+package com.nyanggle.nyangmail.interfaces.dto.fishbread;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MainInfoResDto {
+    private Long totalCount;
+    private Long unreadCount;
+    private String nickname;
+}

--- a/src/main/java/com/nyanggle/nyangmail/persistence/repository/CustomFishBreadRepository.java
+++ b/src/main/java/com/nyanggle/nyangmail/persistence/repository/CustomFishBreadRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.domain.Pageable;
 public interface CustomFishBreadRepository {
     Page<FishBreadListResDto> searchByCondition(String uUid, SearchCondition searchCondition, Pageable pageable);
     Long findFishBreadCountAll(String cartUUid);
-    Long findFishBreadCountNotRead(String uUid, int maxCount);
+    Long findFishBreadCountUnRead(String uUid, int maxCount);
 }

--- a/src/main/java/com/nyanggle/nyangmail/persistence/repository/CustomFishBreadRepositoryImpl.java
+++ b/src/main/java/com/nyanggle/nyangmail/persistence/repository/CustomFishBreadRepositoryImpl.java
@@ -54,14 +54,16 @@ public class CustomFishBreadRepositoryImpl implements CustomFishBreadRepository 
     }
 
     @Override
-    public Long findFishBreadCountNotRead(String uUId, int maxCnt) {
-        return jpaQueryFactory.select(fishBread.count())
+    public Long findFishBreadCountUnRead(String uUId, int maxCnt) {
+        return Long.valueOf(
+                jpaQueryFactory.select(fishBread.id)
                 .from(fishBread)
                 .where(fishBread.receiverUid.eq(uUId),
                         fishBread.status.eq(FishBreadStatus.UNREAD)
                 )
                 .limit(maxCnt)
-                .fetchOne();
+                .fetch().size()
+        );
     }
 
     /**

--- a/src/main/java/com/nyanggle/nyangmail/service/FishBreadService.java
+++ b/src/main/java/com/nyanggle/nyangmail/service/FishBreadService.java
@@ -3,7 +3,9 @@ package com.nyanggle.nyangmail.service;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.FishBreadCreateReqDto;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.FishBreadListResDto;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.FishBreadResDto;
+import com.nyanggle.nyangmail.interfaces.dto.fishbread.MainInfoResDto;
 import com.nyanggle.nyangmail.interfaces.dto.fishbread.SearchCondition;
+import com.nyanggle.nyangmail.oauth.jwt.UserToken;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,8 +14,6 @@ public interface FishBreadService {
     FishBreadResDto findByFishUid(String uUid, Long fishId);
     void fishBreadstatusChange(Long fishId);
     Page<FishBreadListResDto> findBySearchCondition(String uuid, Pageable pageable, SearchCondition searchCondition);
-    Long findFishBreadCountAll(String cartUUid);
-    Long findFishBreadCountNotReadMy(String userId);
-    Long findFishBreadCountNotReadOther(String userId);
     void deleteFishBread(Long fishId, String userId);
+    MainInfoResDto getMainInfo(String cartUUid, UserToken userToken);
 }


### PR DESCRIPTION

## 작업 내용
### 붕어빵 카트 진입시의 정보 호출 API

- 전체, 안 읽은 갯수 나눠 놓은 부분을 22.12.08일 회의를 통해서 합쳐 놓음.
- 추가로 닉네임도 반환.
